### PR TITLE
Fixing `other_packages` and sys.path 

### DIFF
--- a/tests/test-broken-html.py
+++ b/tests/test-broken-html.py
@@ -3,7 +3,7 @@
 parser) can parse.
 """
 
-from _mechanize_dist import ClientForm
+from twill.other_packages._mechanize_dist import ClientForm
 
 import twilltestlib
 from twill import commands

--- a/tests/test-checkbox.py
+++ b/tests/test-checkbox.py
@@ -2,7 +2,7 @@ import twilltestlib
 import twill
 from twill import namespaces, commands
 from twill.errors import TwillAssertionError
-from _mechanize_dist import BrowserStateError, ClientForm
+from twill.other_packages._mechanize_dist import BrowserStateError, ClientForm
 
 def setup_module():
     global url

--- a/tests/test-encoding.py
+++ b/tests/test-encoding.py
@@ -1,5 +1,5 @@
 import twilltestlib
-from _mechanize_dist import ClientForm
+from twill.other_packages._mechanize_dist import ClientForm
 from cStringIO import StringIO
 
 def test_form_parse():

--- a/tests/test-form.py
+++ b/tests/test-form.py
@@ -2,7 +2,7 @@ import twilltestlib
 import twill
 from twill import namespaces, commands
 from twill.errors import TwillAssertionError
-from _mechanize_dist import BrowserStateError, ClientForm
+from twill.other_packages._mechanize_dist import BrowserStateError, ClientForm
 
 def test():
     url = twilltestlib.get_url()

--- a/twill/__init__.py
+++ b/twill/__init__.py
@@ -31,7 +31,7 @@ __all__ = [ "TwillCommandLoop",
             "set_errout"]
 
 #
-# add extensions (twill/extensions) and the the wwwsearch & pyparsing
+# add extensions (twill/extensions)
 # stuff from twill/included-packages/.  NOTE: this works with eggs! hooray!
 #
 
@@ -42,11 +42,6 @@ thisdir = os.path.dirname(__file__)
 # user extensions will take priority over twill extensions.
 extensions = os.path.join(thisdir, 'extensions')
 sys.path.append(extensions)
-
-# add other_packages in at the *beginning*, so that the correct
-# (patched) versions of pyparsing and mechanize get imported.
-wwwsearchlib = os.path.join(thisdir, 'other_packages')
-sys.path.insert(0, wwwsearchlib)
 
 # the two core components of twill:
 from shell import TwillCommandLoop

--- a/twill/_browser.py
+++ b/twill/_browser.py
@@ -3,13 +3,13 @@ A subclass of the mechanize browser patched to fix various bits.
 """
 
 # wwwsearch imports
-from _mechanize_dist import Browser as MechanizeBrowser
+from other_packages._mechanize_dist import Browser as MechanizeBrowser
 
 import wsgi_intercept
 from utils import FixedHTTPBasicAuthHandler, FunctioningHTTPRefreshProcessor
 
 def build_http_handler():
-    from _mechanize_dist._urllib2 import HTTPHandler
+    from other_packages._mechanize_dist._urllib2 import HTTPHandler
 
     class MyHTTPHandler(HTTPHandler):
         def http_open(self, req):

--- a/twill/browser.py
+++ b/twill/browser.py
@@ -10,8 +10,8 @@ OUT=None
 import re
 
 # wwwsearch imports
-import _mechanize_dist as mechanize
-from _mechanize_dist import BrowserStateError, LinkNotFoundError, ClientForm
+import other_packages._mechanize_dist as mechanize
+from other_packages._mechanize_dist import BrowserStateError, LinkNotFoundError, ClientForm
 
 # twill package imports
 from _browser import PatchedMechanizeBrowser

--- a/twill/commands.py
+++ b/twill/commands.py
@@ -4,9 +4,9 @@ twill-sh.
 """
 
 import sys
-import _mechanize_dist as mechanize
-from _mechanize_dist import ClientForm
-from _mechanize_dist._headersutil import is_html
+import other_packages._mechanize_dist as mechanize
+from other_packages._mechanize_dist import ClientForm
+from other_packages._mechanize_dist._headersutil import is_html
 
 OUT=None
 ERR=sys.stderr

--- a/twill/parse.py
+++ b/twill/parse.py
@@ -6,7 +6,7 @@ import sys
 from cStringIO import StringIO
 
 from errors import TwillAssertionError, TwillNameError
-from pyparsing import OneOrMore, Word, printables, quotedString, Optional, \
+from other_packages.pyparsing import OneOrMore, Word, printables, quotedString, Optional, \
      alphas, alphanums, ParseException, ZeroOrMore, restOfLine, Combine, \
      Literal, Group, removeQuotes, CharsNotIn
 

--- a/twill/utils.py
+++ b/twill/utils.py
@@ -8,12 +8,12 @@ code is implemented in the ConfigurableParsingFactory class.
 import os
 import base64
 
-import subprocess
+from other_packages import subprocess
 
-import _mechanize_dist as mechanize
-from _mechanize_dist import ClientForm
-from _mechanize_dist._util import time
-from _mechanize_dist._http import HTTPRefreshProcessor
+import other_packages._mechanize_dist as mechanize
+from other_packages._mechanize_dist import ClientForm
+from other_packages._mechanize_dist._util import time
+from other_packages._mechanize_dist._http import HTTPRefreshProcessor
 
 from errors import TwillException
 


### PR DESCRIPTION
It may cause errors when using twill as a library with other libraries.

For example i had problems with pyparsing, need pyparsing 1.5.5, and i have it installed but twill updates sys.path to use it's own version of pyparsing 1.4.8 and it causes an error for me.
