### PR TITLE
list third-party dependencies in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,9 @@ Web pages or grabbing data from password-protected sites automatically.
                      ],
 
       test_suite = 'nose.collector'
+
+      install_requires = ['cssselect',
+                          'lxml',
+                          'requests',
+                          ],
       )


### PR DESCRIPTION
To unbreak installation via PyPI. Though I strongly recommend to
define specific versions later.
