### PR TITLE
Accept header bug fix

### DIFF
--- a/twill/browser.py
+++ b/twill/browser.py
@@ -38,7 +38,7 @@ class TwillBrowser(object):
 
         # Session stores cookies
         self._session = requests.Session()
-        self._session.headers.update({"Accept" : "text/html; */*"})
+        self._session.headers.update({"Accept" : "text/html, */*"})
 
         # An lxml FormElement, none until a form is selected
         # replaces self._browser.form from mechanize


### PR DESCRIPTION
See http://stackoverflow.com/questions/3796009/retrieve-application-json-document-with-twill-mechanize-in-authenticated-session

Alex Martelli is correct that the ';' should be a , . I had a server reject the ';' separated header, switch to , and no problem.
